### PR TITLE
fix: Implement proper date-based release naming using GitHub Actions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
 # release-drafter の設定ファイル
 # 日付ベースのリリースタグを使用 (release/YYYY-MM-DD)
-name-template: 'Release $DRAFT_RELEASE_DATE'
-tag-template: 'release/$DRAFT_RELEASE_DATE'
+name-template: 'Release $RESOLVED_VERSION'
+tag-template: 'release/$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,15 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - name: Generate release date
+        id: date
+        run: |
+          # 日本時間で日付を取得 (UTC+9)
+          echo "date=$(TZ='Asia/Tokyo' date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          
+      - name: Create Release Draft
+        uses: release-drafter/release-drafter@v6
+        with:
+          version: ${{ steps.date.outputs.date }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixed the issue where release names showed literal `$DRAFT_RELEASE_DATE` instead of actual dates
- Implemented proper date generation in GitHub Actions workflow

## Problem
The previous configuration used `$DRAFT_RELEASE_DATE` which is not a valid release-drafter variable, resulting in:
- Release name: "Release $DRAFT_RELEASE_DATE" 
- Tag name: "release/$DRAFT_RELEASE_DATE"

## Solution
Based on the Qiita article shared, the solution involves:
1. Generate the date in the GitHub Actions workflow using the `date` command
2. Pass the generated date to release-drafter via the `version` parameter
3. Use `$RESOLVED_VERSION` in the templates to receive the date value

## Changes
- Added a step in the workflow to generate current date (using Asia/Tokyo timezone)
- Updated workflow to pass the date as `version` parameter to release-drafter
- Changed templates to use `$RESOLVED_VERSION` instead of invalid `$DRAFT_RELEASE_DATE`

## Result
After this fix:
- Release name: "Release 2025-08-26"
- Tag name: "release/2025-08-26"

## Labels
Please add the `fix` or `bug` label to categorize this under 🐛 Bug Fixes

## Reference
- https://qiita.com/madogiwa/items/87469239d1bee515a514