### PR TITLE
fix: Use direct name and tag parameters to properly format date-based releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,6 @@
 # release-drafter の設定ファイル
 # 日付ベースのリリースタグを使用 (release/YYYY-MM-DD)
-name-template: 'Release $RESOLVED_VERSION'
-tag-template: 'release/$RESOLVED_VERSION'
+# name と tag はワークフローで直接指定するため、ここでは設定不要
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Create Release Draft
         uses: release-drafter/release-drafter@v6
         with:
-          version: ${{ steps.date.outputs.date }}
+          name: "Release ${{ steps.date.outputs.date }}"
+          tag: "release/${{ steps.date.outputs.date }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixes the issue where dates were being parsed as semantic versions (2025.0.0)
- Uses direct `name` and `tag` parameters in the workflow

## Problem
When using the `version` parameter, release-drafter was interpreting the date string "2025-08-26" as a semantic version, resulting in:
- Release name: "Release 2025.0.0"
- Tag: "release/2025.0.0"

## Solution
Based on the Zenn article, the solution is to:
1. Specify `name` and `tag` parameters directly in the workflow
2. Remove the `version` parameter to avoid semantic version parsing
3. Simplify the config file since templates are no longer needed

## Changes
- Updated workflow to use `name` and `tag` parameters directly
- Removed `version` parameter from workflow
- Simplified release-drafter.yml config file

## Expected Result
- Release name: "Release 2025-08-26"
- Tag: "release/2025-08-26"

## Labels
Please add the `fix` label to categorize this under 🐛 Bug Fixes